### PR TITLE
CED-61974: Add between operator and alias for nin operator

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,10 +23,10 @@ jobs:
         run: |
           changed_files=$(git diff --name-only --diff-filter=d origin/main..HEAD | grep -E '*\.py$' | tr '\n' ' ')
           echo "::set-output name=changed_py_files::$changed_files"
-      - name: Set up Python 3.6
+      - name: Set up Python
         uses: actions/setup-python@dc73133d4da04e56a135ae2246682783cc7c7cb6 #pin to latest version v2.2.2
         with:
-          python-version: 3.6
+          python-version: 3.7
       - name: Install python packages
         run: pip install -e .[test]
       - name: black

--- a/README.md
+++ b/README.md
@@ -219,18 +219,18 @@ execute(operations, data1) # -> False
 execute(operations, data2) # -> True
 ```
 
-### nin (Not In operator)
+### !in (Not In operator)
 Check whether one value is NOT contained in another.
 
 ##### Syntax
 ```python
-["nin", <operator_or_literal>, <operator_or_literal>]
+["!in", <operator_or_literal>, <operator_or_literal>]
 ```
 
 ##### Example
 ```python
 from json_operations import execute
-operations = ["nin", "my_type",  ["key", "types"]]
+operations = ["!in", "my_type",  ["key", "types"]]
 data1 = {
     "types": [
         "type1", "type2"
@@ -240,6 +240,33 @@ data2 = {
     "types": [
         "my_type", "type1"
     ]
+}
+
+execute(operations, data1) # -> True
+execute(operations, data2) # -> False
+```
+### btw (Between operator)
+Check whether one value is between 2 other values. Equivalent to
+```
+low <= val <= high
+```
+Both low and high value are included.
+
+
+##### Syntax
+```python
+["btw", <value_operator_or_literal>, [<low_operator_or_literal>, <high_operator_or_literal>]]
+```
+
+##### Example
+```python
+from json_operations import execute
+operations = ["btw", ["key", "val"],  [1, 3]]
+data1 = {
+    "val": 2
+}
+data2 = {
+    "val" : 4
 }
 
 execute(operations, data1) # -> True


### PR DESCRIPTION
## Summary
Jira: https://cedar-jira.atlassian.net/browse/CED-61974

This adds the between operator as an option for json operations

## Test Plan
##### How can reviewers test your change manually?
Check you can add `btw`  operation

##### What automated tests did you add? If none, please state why.
Added automated tests
