### PR TITLE
feat(logic): add intersection operator &

### DIFF
--- a/json_operations/__init__.py
+++ b/json_operations/__init__.py
@@ -40,6 +40,7 @@ def get_json_schema() -> Dict:
                             "nin",
                             "!in",
                             "btw",
+                            "&",
                         ]
                     },
                     {
@@ -187,6 +188,13 @@ def _between(val, range):
     return range[0] <= val <= range[1]
 
 
+def _intersection(a, b):
+    if not isinstance(a, list) or not isinstance(b, list):
+        raise TypeError("intersection operator must be used with 2 lists")
+
+    return bool(set(a) & set(b))
+
+
 @_raise_type_error("!=")
 def _not_equal(a, b):
     if not _same_type(a, b):
@@ -221,6 +229,7 @@ _operators = {
     "nin": _not_in,
     "!in": _not_in,
     "btw": _between,
+    "&": _intersection,
 }
 
 _nesting_operators = {"and", "or"}

--- a/tests/test_json_operations.py
+++ b/tests/test_json_operations.py
@@ -10,6 +10,7 @@ from json_operations import (
     _greater,
     _greater_or_equal,
     _in,
+    _intersection,
     _less,
     _less_or_equal,
     _not_equal,
@@ -180,6 +181,21 @@ class TestJsonOperations(TestCase):
 
     @parameterized.expand(
         [
+            ([], [], False),
+            ([0], [0], True),
+            ([1, 0], [0, 2], True),
+            ([1, 2, 3], [3], True),
+            ([1, "2", 3], ["2"], True),
+            ([1], ["1"], False),
+            ([], [0], False),
+            ([0], [], False),
+        ]
+    )
+    def test_intersection_operator(self, a, b, result):
+        self.assertEqual(_intersection(a, b), result)
+
+    @parameterized.expand(
+        [
             (2, [1, "a"]),
             (2, ["a", 1]),
             ("hello", [1, 2]),
@@ -277,6 +293,28 @@ class TestJsonOperations(TestCase):
                 ],
                 dict(
                     customer_balance=100,
+                ),
+                True,
+            ),
+            (
+                [
+                    "&",
+                    ["key", "ids"],
+                    [2],
+                ],
+                dict(
+                    ids=[3],
+                ),
+                False,
+            ),
+            (
+                [
+                    "&",
+                    ["key", "ids"],
+                    [2],
+                ],
+                dict(
+                    ids=[1, 2],
                 ),
                 True,
             ),


### PR DESCRIPTION
## Summary
This adds the intersection operator to json operations. It will be used for this PR
Jira: https://cedar-jira.atlassian.net/browse/CED-63209

## Test Plan
##### How can reviewers test your change manually?
Check you can use `&` operator with 2 lists now
##### What automated tests did you add? If none, please state why.
Added unit test for new operator
